### PR TITLE
Fix typo

### DIFF
--- a/test/5.2.11.sh
+++ b/test/5.2.11.sh
@@ -12,5 +12,5 @@ fi
 for MAC in $(echo $MACs | sed "s/,/ /g")
 do
         echo MAC = $MAC
-        echo "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com" | grep "$MAC" || exit $?
+        echo "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com" | grep "$MAC" || exit $?
 done


### PR DESCRIPTION
Fixes a typo in the MAC list for "umac-128-etm@openssh.com"