### PR TITLE
[FIX][TYPO]

### DIFF
--- a/test/4.1.8.sh
+++ b/test/4.1.8.sh
@@ -3,5 +3,5 @@
 
 # 4.1.8 - Ensure login and logout events are collected (Scored)
 
-cut -d\# -f1 /etc/audit/audit.rules | egrep "\-k[[:space:]]+logins" | egrep "\-p[[:space:]]+wa"   | egrep -q "\-w[[:space:]]+\/var\/run\/faillog" || exit 1
+cut -d\# -f1 /etc/audit/audit.rules | egrep "\-k[[:space:]]+logins" | egrep "\-p[[:space:]]+wa"   | egrep -q "\-w[[:space:]]+\/var\/run\/faillock" || exit 1
 cut -d\# -f1 /etc/audit/audit.rules | egrep "\-k[[:space:]]+logins" | egrep "\-p[[:space:]]+wa" | egrep -q "\-w[[:space:]]+\/var\/log\/lastlog" || exit 1


### PR DESCRIPTION
Searching for /var/run/faillock as in CIS benchmark instead of /var/run/faillog